### PR TITLE
Redirects to the bundlephobia.com website

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ async function main() {
 
 		alfy.output([{
             title: `${ name}@${ version }`,
-            subtitle: `Size: ${formatBytes(size)}, Gzip: ${formatBytes(gzip)}`
+            subtitle: `Size: ${formatBytes(size)}, Gzip: ${formatBytes(gzip)}`,
+	    arg: `https://bundlephobia.com/result?p=${name}@{version}`,
+	    quicklookurl: `https://bundlephobia.com/result?p=${name}@{version}`
         }]);
 	} catch (e) {
 		alfy.error(e.message);


### PR DESCRIPTION
I find it useful to actually see the graphs displayed on https://bundlephobia.com. It helps to understand if a size is correct or not.

With this PR, the user will be redirected to the bundlephobia web application once hitting the `Enter` key.

For example:

1. I type `bundlephobia lodash` in Alfred
2. Then hit `Enter`
3. I get redirected to https://bundlephobia.com/result?p=lodash